### PR TITLE
Fixed typo in name of "AIImageMeanAbsoluteError" (Issue #2)

### DIFF
--- a/AIImageCompare/AIImageCompare.h
+++ b/AIImageCompare/AIImageCompare.h
@@ -30,7 +30,7 @@ typedef NSImage AIImage;
 /**
  Find the Mean Absolute Error (MAE) between two images of the same size. This is the most common way of finding if two images differ and by what amount.
  */
-CG_EXTERN CGFloat AIImageMeanAbosulteError(AIImage* image1, AIImage* image2);
+CG_EXTERN CGFloat AIImageMeanAbsoluteError(AIImage* image1, AIImage* image2);
 
 /**
  Find the Root Mean Square Error (RMSE) between two images of the same size. The RMSE puts more weight in large-magnitude variations than the MAE.

--- a/AIImageCompare/AIImageCompare.m
+++ b/AIImageCompare/AIImageCompare.m
@@ -34,7 +34,7 @@ CGImageRef CGImageFromImage(AIImage* image) {
 }
 #endif
 
-CG_EXTERN CGFloat AIImageMeanAbosulteError(AIImage* image1, AIImage* image2) {
+CG_EXTERN CGFloat AIImageMeanAbsoluteError(AIImage* image1, AIImage* image2) {
     CGImageRef cgimage1 = CGImageFromImage(image1);
     CGImageRef cgimage2 = CGImageFromImage(image2);
 

--- a/AIImageCompareTests/AIImageCompareTests.m
+++ b/AIImageCompareTests/AIImageCompareTests.m
@@ -35,14 +35,14 @@
 
 - (void)testMeanAbsoluteErrorSame {
     UIImage* image = [self testImageWithName:@"1123"];
-    CGFloat mae = AIImageMeanAbosulteError(image, image);
+    CGFloat mae = AIImageMeanAbsoluteError(image, image);
     XCTAssertEqual(mae, 0, @"The MAE of an image with itself should be 0");
 }
 
 - (void)testMeanAbsoluteErrorDifferent {
     UIImage* image1 = [self testImageWithName:@"1123"];
     UIImage* image2 = [self testImageWithName:@"1124"];
-    CGFloat mae = AIImageMeanAbosulteError(image1, image2);
+    CGFloat mae = AIImageMeanAbsoluteError(image1, image2);
     XCTAssertEqualWithAccuracy(mae, 0.00012, 0.00001, @"The MAE of different images should be around 0.00012");
 }
 


### PR DESCRIPTION
This fixes a typo in one of the two functions, renaming AIImageMean**Abosulte**Error to AIImageMean**Absolute**Error
